### PR TITLE
build sdists too

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "rsmarkov"
 version = "0.1.2"
 authors = ["bijij <josh@josh-is.gay>"]
 edition = "2018"
-include = ["src/lib.rs", "README.md"]
+include = ["src/lib.rs", "README.md", "pyproject.toml"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["maturin~=0.11.0"]
+build-backend = "maturin"


### PR DESCRIPTION
While I have tested that `maturin sdist` works, I have not tested `maturin build` as I do not have python3.6 installed, and I didn't see a way to get maturin to upload to TestPyPI either. `maturin build` seems to do sdists by default, though.